### PR TITLE
Update providers.py

### DIFF
--- a/lib/python/Plugins/SystemPlugins/OpentvZapper/providers.py
+++ b/lib/python/Plugins/SystemPlugins/OpentvZapper/providers.py
@@ -3,6 +3,7 @@ from enigma import eDVBFrontendParametersSatellite
 
 providers = {
 	"Astra 28.2": {
+		"service_provider": "BSkyB",
 		"transponder": {
 			'orbital_position': 282,
 			'inversion': 2,
@@ -30,5 +31,76 @@ providers = {
 			'service_cachedpids': [(1, 0x0288), (3, 0x1ffe)],
 			'service_capids': None,
 			},
-		}
-	}
+		},
+
+	"Koreasat-6 160 NZ": {
+		"service_provider": "SKYNZ",
+		"transponder": {
+			'orbital_position': 1600,		# 160.0°E
+			'inversion': 2,					# 0=Off, 1=On, 2=Auto
+			'symbol_rate': 30000000,		# ks/s
+			'namespace': 104857600,
+			'system': 1,					# 0 = DVB-S, 1 = DVB-S2
+			'polarization': 0,				# 0 = H, 1 = V
+			'original_network_id': 169,
+			'fec_inner': 7,					# 0=Auto, 1=1/2, 2=2/3, 3=3/4, 4=5/6, 5=7/8, 6=8/9, 7=3/5, 8=4/5, 9=9/10, 10=6/7, 15=None
+			'frequency': 12530000,			# Hz
+			'flags': 0,
+			'transport_stream_id': 3,
+			'modulation': 1,				# 0=Auto, 1=QPSK, 2=8PSK, 3=16APSK, 4=32APSK, 5=BPSK
+			'dvb_type': 'dvbs2',
+			'pilot': 2,						# 0=Off, 1=On, 2=Auto
+			'rolloff': 0,					# 0=0.35, 1=0.25, 2=0.20, 3=Auto
+			'services': {},
+		},
+
+		"service": {
+			'service_name': 'TS3 IEPG Data Service',
+			'namespace': 104857600,
+			'original_network_id': 169,
+			'flags': 0,
+			'service_id': 9003,
+			'transport_stream_id': 3,
+			'service_type': 1,
+			'service_provider': 'SKYNZ',
+			'service_line': 'p:SKYNZ',
+			'service_cachedpids': None,
+			'service_capids': None,
+		},
+	},
+
+# Needs to be tested on Hotbird
+#	"Hotbird 13.0": {
+#		"service_provider": "Sky Italia",
+#		"transponder": {
+#			'orbital_position': 130,		# 13.0°E
+#			'inversion': 2,					# 0=Off, 1=On, 2=Auto
+#			'symbol_rate': 29900000,		# ks/s
+#			'namespace': 8519680,
+#			'system': 1,					# 0 = DVB-S, 1 = DVB-S2
+#			'polarization': 1,				# 0 = H, 1 = V
+#			'original_network_id': 318,
+#			'fec_inner': 3,					# 0=Auto, 1=1/2, 2=2/3, 3=3/4, 4=5/6, 5=7/8, 6=8/9, 7=3/5, 8=4/5, 9=9/10, 10=6/7, 15=None
+#			'frequency': 11766000,			# Hz
+#			'flags': 0,
+#			'transport_stream_id': 5200,
+#			'modulation': 2,				# 0=Auto, 1=QPSK, 2=8PSK, 3=16APSK, 4=32APSK, 5=BPSK
+#			'dvb_type': 'dvbs2',
+#			'pilot': 1,						# 0=Off, 1=On, 2=Auto
+#			'rolloff': 2,					# 0=0.35, 1=0.25, 2=0.20, 3=Auto
+#			'services': {},
+#		},
+#
+#		"service": {
+#			'service_name': 'OpenTV EPG',	# not sure this is right
+#			'namespace': 8519680,
+#			'original_network_id': 64511,	# special EPG service ONID
+#			'flags': 0,
+#			'service_id': 3635,				# SID
+#			'transport_stream_id': 5200,
+#			'service_type': 1,
+#			'service_cachedpids': None,
+#			'service_capids': None,
+#		},
+#	},
+}


### PR DESCRIPTION
@huevos Largley left astra 28.2 alone.. just added a provider name.. 
I am curious that it works as there doesn't see to be a transponder frequency published for 11778000
Previos attempts to commit a change to this file, before never changed any settings.. just added comments to end of each setting

This change is mostly adding in new provider for NZ, this has been tested an works in NZ

and also, drafting a provider for Hotbird 13.0, based on limited CrossEPG data.  that someone will need to test and adjust.

Someone may want to alter the other code, as astra 28.2 is hardcoded as the default provider, so if someone ways playing with their own providers file, they need to keep astra 28.2, else opentvzapper will crash

I hope this is ok, maybe you can getsome one who uses 28.2 to test these chanegs don't impact them before closing the change